### PR TITLE
fix(tsconfig): use moduleResolution bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     /* Modules */
     "module": "esnext",
     /* Specify what module code is generated. */ // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     /* Specify how TypeScript looks up a file from a given module specifier. */ // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
TypeScript 7 removes the `node10` resolution mode that `"moduleResolution": "node"` maps to, so `tsc --noEmit` fails with `TS5108: Option 'moduleResolution=node10' has been removed`.

`bundler` is the correct mode for this project, which already uses `module: esnext` and is bundled by Wrangler/esbuild.

Verified locally: `tsc --noEmit` is clean under both TypeScript 6.0.3 (current) and 7.0.2 (#198).